### PR TITLE
Add ENV variable for the image directory

### DIFF
--- a/app/importers/csv_importer.rb
+++ b/app/importers/csv_importer.rb
@@ -15,8 +15,10 @@ class CsvImporter
       image.depositor = @user.email
       # Attach the image file and run it through the actor stack
       # Try entering Hyrax::CurationConcern.actor on a console to see all of the
-      # actors this object will run through.
-      image_binary = File.open("#{::Rails.root}/spec/fixtures/images/#{row[0]}")
+
+      # To set when running the rake task:
+      # $ IMPORT_FILE_PATH=opt/data rake sample:import[bluestar_test1.csv]
+      image_binary = File.open("#{ENV['IMPORT_FILE_PATH']}/#{row[0]}")
       uploaded_file = Hyrax::UploadedFile.create(user: @user, file: image_binary)
       attributes_for_actor = { uploaded_files: [uploaded_file.id] }
       env = Hyrax::Actors::Environment.new(image, ::Ability.new(@user), attributes_for_actor)

--- a/spec/importers/csv_importer_spec.rb
+++ b/spec/importers/csv_importer_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+ENV['IMPORT_FILE_PATH'] = "spec/fixtures/images"
 
 require 'rails_helper'
 require 'active_fedora/cleaner'


### PR DESCRIPTION
### The rake Task
$ `IMPORT_FILE_PATH=opt/data rake sample:import[bluestar_test1.csv]` 

---

` image_binary = File.open("#{ENV['IMPORT_FILE_PATH']}/#{row[0]}")`

---

Changes to be committed:
modified:   app/importers/csv_importer.rb